### PR TITLE
Make "newflasher" the new default target (#9)

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,9 @@ STRIP=strip
 CFLAGS=-Wall -O2
 CROSS_CFLAGS=${CFLAGS} -static -I include -I expat/include -L /usr/local/lib -L /usr/lib -L lib -L expat/lib
 
-default:newflasher.exe newflasher.x64 newflasher.i386 newflasher.arm32 newflasher.arm64
+default: newflasher
+
+cross: newflasher.exe newflasher.x64 newflasher.i386 newflasher.arm32 newflasher.arm64
 
 newflasher: newflasher.c GordonGate.h
 	${CC} ${CFLAGS} $< -o $@ -lz -lexpat


### PR DESCRIPTION
This ensures that for normal users on a simple Linux installation, a
plain "make" performs expected native build, rather than throwing
errors about missing cross-compilers.

The old default target that builds all statically linked and
cross-compiled binaries is still available via "make cross".

#9