### PR TITLE
makefile: do not strip man page

### DIFF
--- a/makefile
+++ b/makefile
@@ -96,7 +96,7 @@ install: newflasher newflasher.1.gz
 	$(INSTALL) -o root -g root -d $(DESTDIR)/usr/bin
 	$(INSTALL) -o root -g root -m 755 -s newflasher $(DESTDIR)/usr/bin/
 	$(INSTALL) -o root -g root -d $(DESTDIR)/usr/share/man/man1
-	$(INSTALL) -o root -g root -m 644 -s newflasher.1.gz $(DESTDIR)/usr/share/man/man1
+	$(INSTALL) -o root -g root -m 644 newflasher.1.gz $(DESTDIR)/usr/share/man/man1
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Current makefile "strips" newflasher.1.gz with `install ... -s`, this results in error 1 during `make install`...

```
install -o root -g root -m 644 -s newflasher.1.gz /var/cache/acbs/build/acbs.5zkja8yr/newflasher-33/abdist/usr/share/man/man1
strip: /var/cache/acbs/build/acbs.5zkja8yr/newflasher-33/abdist/usr/share/man/man1/newflasher.1.gz: file format not recognized
install: strip process terminated abnormally
make: *** [makefile:99: install] Error 1
```

This pull request removes the erroneous `-s` flag when installing `newflasher.1.gz`.