### PR TITLE
Fix potential buffer overflow in get_reply()

### DIFF
--- a/newflasher.c
+++ b/newflasher.c
@@ -1121,6 +1121,12 @@ static bool get_reply(HANDLE dev, int ep, char *bytes, unsigned long size, int t
 		return false;
 	}
 
+	if (ret_len > BUFF_MAX)
+	{
+		printf("Bug!!! ret_len: 0x%x > BUFF_MAX: 0x%x\n", ret_len, BUFF_MAX);
+		return false;
+	}
+
 	if (ret_len >= 4)
 	{
 


### PR DESCRIPTION
$ ./newflasher Read-partition:appslog
\--------------------------------------------------------
            newflasher v59 by Munjeni @ 2017/2025
\--------------------------------------------------------

Determining available free space:

  Available space to caller    = 40132 MB
  Total space on current drive = 64359 MB
  Free space on drive          = 40132 MB
cannot open /dev/bus/usb/006/003 for writing
cannot open /dev/bus/usb/006/001 for writing
cannot open /dev/bus/usb/005/099 for writing
cannot open /dev/bus/usb/005/092 for writing
cannot open /dev/bus/usb/005/001 for writing
cannot open /dev/bus/usb/004/001 for writing
cannot open /dev/bus/usb/003/001 for writing
cannot open /dev/bus/usb/002/001 for writing
found device with vid:0x0fce pid:0xb00b.

update.xml not exist in current folder!
Writing command: Read-partition:appslog
got first reply[0xC]:

  00000000  44 41 54 41 30 31 30 30 30 30 30 30              DATA01000000

Bug!!! ret_len: 0x1000000 > BUFF_MAX: 0x800000
Error retrieving data!
Closing device.